### PR TITLE
Read series from voucher if present

### DIFF
--- a/lib/sie/document.rb
+++ b/lib/sie/document.rb
@@ -73,14 +73,17 @@ module Sie
 
 
     def add_voucher(opts)
-      creditor      = opts.fetch(:creditor)
-      type          = opts.fetch(:type)
-      number        = opts.fetch(:number)
-      booked_on     = opts.fetch(:booked_on)
-      description   = opts.fetch(:description).slice(0, DESCRIPTION_LENGTH_MAX)
-      voucher_lines = opts.fetch(:voucher_lines)
+      number         = opts.fetch(:number)
+      booked_on      = opts.fetch(:booked_on)
+      description    = opts.fetch(:description).slice(0, DESCRIPTION_LENGTH_MAX)
+      voucher_lines  = opts.fetch(:voucher_lines)
+      voucher_series = opts.fetch(:series) do
+        creditor = opts.fetch(:creditor)
+        type = opts.fetch(:type)
+        VoucherSeries.for(creditor, type)
+      end
 
-      add_line("VER", voucher_series(creditor, type), number, booked_on, description)
+      add_line("VER", voucher_series, number, booked_on, description)
 
       add_array do
         voucher_lines.each do |line|
@@ -111,10 +114,6 @@ module Sie
 
     def financial_years
       data_source.financial_years.sort_by { |date_range| date_range.first }.reverse
-    end
-
-    def voucher_series(creditor, type)
-      VoucherSeries.for(creditor, type)
     end
   end
 end

--- a/lib/sie/document.rb
+++ b/lib/sie/document.rb
@@ -77,11 +77,11 @@ module Sie
       booked_on      = opts.fetch(:booked_on)
       description    = opts.fetch(:description).slice(0, DESCRIPTION_LENGTH_MAX)
       voucher_lines  = opts.fetch(:voucher_lines)
-      voucher_series = opts.fetch(:series) do
+      voucher_series = opts.fetch(:series) {
         creditor = opts.fetch(:creditor)
         type = opts.fetch(:type)
         VoucherSeries.for(creditor, type)
-      end
+      }
 
       add_line("VER", voucher_series, number, booked_on, description)
 

--- a/spec/unit/document_spec.rb
+++ b/spec/unit/document_spec.rb
@@ -202,7 +202,7 @@ describe Sie::Document, "#render" do
       ]
     }
 
-    it "ensures there are at least two lines" do
+    it "reads the series from the voucher" do
       expect(indexed_entry("ver", 0).attributes["serie"]).to eq("X")
     end
   end

--- a/spec/unit/document_spec.rb
+++ b/spec/unit/document_spec.rb
@@ -195,6 +195,18 @@ describe Sie::Document, "#render" do
     end
   end
 
+  context "with a series defined" do
+    let(:vouchers) {
+      [
+        build_voucher(series: "X")
+      ]
+    }
+
+    it "ensures there are at least two lines" do
+      expect(indexed_entry("ver", 0).attributes["serie"]).to eq("X")
+    end
+  end
+
   private
 
   def build_voucher(attributes)

--- a/spec/unit/document_spec.rb
+++ b/spec/unit/document_spec.rb
@@ -198,7 +198,7 @@ describe Sie::Document, "#render" do
   context "with a series defined" do
     let(:vouchers) {
       [
-        build_voucher(series: "X")
+        build_voucher(series: "X"),
       ]
     }
 


### PR DESCRIPTION
In order to allow users of the library to use their own logic for determining what series a voucher belongs to, read series from voucher if present.

Todo:
- [ ] Mention this behavior in `README.md`?