### PR TITLE
Add support for voucher line dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ class YourDataSource
     [ 3100 ]
   end
 
+  def dimensions
+    [
+      {
+        number: 6,
+        description: "Projekt",
+        objects: [
+          { number: 1, description: "Education" }
+        ]
+      }
+    ]
+  end
+
   # Used to calculate balance before (and on) the given date for an account.
   def balance_before(account_number, date)
     # ActiveRecord example:
@@ -90,7 +102,8 @@ class YourDataSource
           },
           {
             account_number: 3100, amount: -512.0,
-            booked_on: Date.today, description: "Item 1"
+            booked_on: Date.today, description: "Item 1",
+            dimensions: { 6 => 1 }
           },
         ]
       }

--- a/lib/sie/document.rb
+++ b/lib/sie/document.rb
@@ -105,7 +105,7 @@ module Sie
           account_number = line.fetch(:account_number)
           amount         = line.fetch(:amount)
           booked_on      = line.fetch(:booked_on)
-          dimensions     = line.fetch(:dimensions, {}).to_a.flatten
+          dimensions     = line.fetch(:dimensions, {}).flatten
           # Some SIE-importers (fortnox) cannot handle descriptions longer than 30 characters,
           # but the specification has no limit.
           description    = line.fetch(:description).slice(0, DESCRIPTION_LENGTH_MAX)

--- a/lib/sie/document/renderer.rb
+++ b/lib/sie/document/renderer.rb
@@ -44,7 +44,7 @@ class Sie::Document::Renderer
     when Date
       value.strftime("%Y%m%d")
     when Array
-      subvalues = value.map { |subvalue| format_value(subvalue) }
+      subvalues = value.map { |subvalue| format_value(subvalue.to_s) }
       "{#{subvalues.join(' ')}}"
     when Numeric
       value.to_s

--- a/lib/sie/document/renderer.rb
+++ b/lib/sie/document/renderer.rb
@@ -1,7 +1,6 @@
 require "stringio"
 
 class Sie::Document::Renderer
-  EMPTY_ARRAY = :empty_array
   ENCODING = Encoding::CP437
 
   def initialize
@@ -44,8 +43,9 @@ class Sie::Document::Renderer
     case value
     when Date
       value.strftime("%Y%m%d")
-    when EMPTY_ARRAY
-      "{}"
+    when Array
+      subvalues = value.map { |subvalue| format_value(subvalue) }
+      "{#{subvalues.join(' ')}}"
     when Numeric
       value.to_s
     else

--- a/lib/sie/parser/build_entry.rb
+++ b/lib/sie/parser/build_entry.rb
@@ -21,14 +21,15 @@ module Sie
         entry = build_empty_entry
 
         attributes_with_tokens.each do |attr, *attr_tokens|
-          label = attr.is_a?(Hash) ? attr[:name] : attr
+          label = attr.is_a?(Hash) ? attr.fetch(:name) : attr
 
           if attr_tokens.size == 1
             entry.attributes[label] = attr_tokens.first
           else
+            type = attr.fetch(:type)
             values = attr_tokens.
-              each_slice(attr[:type].size).
-              map { |slice| Hash[attr[:type].zip(slice)] }
+              each_slice(type.size).
+              map { |slice| Hash[type.zip(slice)] }
             entry.attributes[label] = values
           end
         end

--- a/lib/sie/parser/build_entry.rb
+++ b/lib/sie/parser/build_entry.rb
@@ -46,7 +46,7 @@ module Sie
             [attr_entry_type, token.value]
           else
             unless token.is_a?(Tokenizer::BeginArrayToken)
-              raise IOError, "Unexpected token #{token.inspect}"
+              raise InvalidEntryError, "Unexpected token: #{token.inspect}"
             end
 
             hash_tokens = []

--- a/lib/sie/parser/tokenizer.rb
+++ b/lib/sie/parser/tokenizer.rb
@@ -16,7 +16,7 @@ module Sie
           move_to_next_character
           break unless current_character.value
 
-          if consume?
+          if consume? && !current_character.end_of_array?
             if quoted?
               consume_quoted_value
             else

--- a/lib/sie/parser/tokenizer.rb
+++ b/lib/sie/parser/tokenizer.rb
@@ -16,7 +16,7 @@ module Sie
           move_to_next_character
           break unless current_character.value
 
-          if consume? && !current_character.end_of_array?
+          if consume?
             if quoted?
               consume_quoted_value
             else
@@ -42,6 +42,7 @@ module Sie
       def consume_quoted_value
         if current_character.quote?
           @quoted = false
+          @consume = false
         else
           add_to_current_token current_character
         end

--- a/spec/unit/build_entry_spec.rb
+++ b/spec/unit/build_entry_spec.rb
@@ -1,0 +1,20 @@
+require "spec_helper"
+require "sie/parser/build_entry"
+require "sie/parser/tokenizer"
+
+module Sie
+  class Parser
+    describe BuildEntry, "call" do
+      context "with an unexpected token at start of array" do
+        it "raises InvalidEntryError" do
+          line = '#TRANS 2400 [] -200 20130101 "Foocorp expense"'
+          tokens = Tokenizer.new(line).tokenize
+          first_token = tokens.shift
+          build_entry = BuildEntry.new(line, first_token, tokens, false)
+
+          expect { build_entry.call }.to raise_error(BuildEntry::InvalidEntryError)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/parser/line_parser_spec.rb
+++ b/spec/unit/parser/line_parser_spec.rb
@@ -3,14 +3,15 @@ require "sie/parser/line_parser"
 
 describe Sie::Parser::LineParser, "parse" do
   it "parses lines from a sie file" do
-    parser = Sie::Parser::LineParser.new('#TRANS 2400 {} -200 20130101 "Foocorp expense"')
+    parser = Sie::Parser::LineParser.new('#TRANS 2400 {"3" "5"} -200 20130101 "Foocorp expense"')
     entry = parser.parse
     expect(entry.label).to eq("trans")
     expect(entry.attributes).to eq({
       "kontonr" => "2400",
       "belopp"  => "-200",
       "transdat" => "20130101",
-      "transtext" => "Foocorp expense"
+      "transtext" => "Foocorp expense",
+      "objektlista" => [{"dimensionsnr" => "3", "objektnr" => "5"}],
     })
   end
 
@@ -32,10 +33,5 @@ describe Sie::Parser::LineParser, "parse" do
         expect { parser.parse }.to raise_error(/Unknown entry type/)
       end
     end
-  end
-
-  it "fails if you have non empty metadata arrays until there is a need to support that" do
-    parser = Sie::Parser::LineParser.new('#TRANS 2400 { 1 "2" } -200 20130101 "Foocorp expense"')
-    expect(-> { parser.parse }).to raise_error(/don't support metadata/)
   end
 end


### PR DESCRIPTION
As a user of this library
In order to integrate with other bookkeeping software
I want this library to support voucher line dimensions

This change is currently backward incompatible, as it requires making the data source respond to `dimensions`.

Feedback (including nitpicks) is appreciated, especially on how to clean up `LineParser`.

TODO:
- [x] Update README