### PR TITLE
Introduced option to make parser more lenient regarding unknown entry types

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ File.open("path/to/file.se") do |f|
 end
 ```
 
+By default the parser will raise an error if it encounters unknown entry types. Use the lenient option to avoid this:
+
+```ruby
+parser = Sie::Parser.new(lenient: true)
+```
+
 For more info, see the specs.
 
 ## Developing

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ File.open("path/to/file.se") do |f|
 end
 ```
 
-By default the parser will raise an error if it encounters unknown entry types. Use the lenient option to avoid this:
+By default the parser will raise an error if it encounters unknown entry types. Use the `lenient` option to avoid this:
 
 ```ruby
 parser = Sie::Parser.new(lenient: true)

--- a/lib/sie/parser.rb
+++ b/lib/sie/parser.rb
@@ -9,6 +9,10 @@ module Sie
     END_OF_ARRAY       = "}"
     ENTRY              = /^#/
 
+    def initialize(options = {})
+      @options = options
+    end
+
     def parse(io)
       stack = []
       sie_file = SieFile.new
@@ -33,8 +37,14 @@ module Sie
 
     private
 
+    attr_reader :options
+
+    def lenient
+      options.fetch(:lenient, false)
+    end
+
     def parse_line(line)
-      LineParser.new(line).parse
+      LineParser.new(line, lenient: lenient).parse
     end
   end
 end

--- a/lib/sie/parser.rb
+++ b/lib/sie/parser.rb
@@ -9,6 +9,8 @@ module Sie
     END_OF_ARRAY       = "}"
     ENTRY              = /^#/
 
+    attr_private :options
+
     def initialize(options = {})
       @options = options
     end
@@ -36,8 +38,6 @@ module Sie
     end
 
     private
-
-    attr_reader :options
 
     def lenient
       options.fetch(:lenient, false)

--- a/lib/sie/parser/line_parser.rb
+++ b/lib/sie/parser/line_parser.rb
@@ -5,13 +5,14 @@ require "sie/parser/sie_file"
 module Sie
   class Parser
     class LineParser
-      pattr_initialize :line, [:lenient]
+      pattr_initialize :line, [ :lenient ]
 
       def parse
         tokens = tokenize(line)
         first_token = tokens.shift
 
         entry = Entry.new(first_token.label)
+
         if first_token.known_entry_type?
           build_entry(entry, first_token, tokens)
         else

--- a/lib/sie/parser/line_parser.rb
+++ b/lib/sie/parser/line_parser.rb
@@ -16,7 +16,9 @@ module Sie
         if first_token.known_entry_type?
           build_entry(entry, first_token, tokens)
         else
-          raise "Unknown entry type: #{first_token.label}" unless lenient
+          unless lenient
+            raise "Unknown entry type: #{first_token.label}. Pass 'lenient: true' to Parser.new to avoid exception."
+          end
         end
 
         entry

--- a/lib/sie/parser/tokenizer/token.rb
+++ b/lib/sie/parser/tokenizer/token.rb
@@ -10,6 +10,10 @@ module Sie
           @value = value
         end
 
+        def known_entry_type?
+          Sie::Parser::ENTRY_TYPES.has_key?(label)
+        end
+
         def entry_type
           Sie::Parser::ENTRY_TYPES.fetch(label)
         end

--- a/spec/fixtures/sie_file_with_unknown_entries.se
+++ b/spec/fixtures/sie_file_with_unknown_entries.se
@@ -1,0 +1,32 @@
+#FLAGGA 0
+#PROGRAM "fooconomic" "1.0"
+#FORMAT PC8
+#GEN 20130101
+#SIETYP 4
+#ORGNR 555555-5555
+#FNAMN "Foocorp"
+#ADRESS "Foocorp" "" "12345 City" "555-12345"
+#KONTO 1510 "Accounts receivable"
+#KTYP 1510 T
+#SRU 1510 204
+#KONTO 1930 "Bank account"
+#KTYP 1930 T
+#SRU 1930 200
+#KONTO 2440 Supplier
+#KTYP 2440 S
+#SRU 2440 300
+#KONTO 2610 "Utgaende moms, oreducerad "
+#KTYP 2610 S
+#SRU 2610 7369
+#MOMSKOD 2610 10
+#VER A 1 20130101 "Invoice" 20120105
+{
+   #TRANS 1510 {} -200 20130101 "Coffee machine"
+   #TRANS 4100 {} 180 20130101 "Coffee machine"
+   #TRANS 2611 {} -20 20130101 "VAT"
+}
+#VER A 2 20130102 "Payment" 20120105
+{
+   #TRANS 1510 {} -200 20130101 "Payment: Coffee machine"
+   #TRANS 1970 {} 200 20130101 "Payment: Coffee machine"
+}

--- a/spec/integration/parser_spec.rb
+++ b/spec/integration/parser_spec.rb
@@ -18,7 +18,39 @@ describe Sie::Parser do
     end
   end
 
-  def open_file(fixture_file)
-    File.open(File.join(File.dirname(__FILE__), "../#{fixture_file}"))
+  context 'unknown entries' do
+    let(:file_with_unknown_entries) { "fixtures/sie_file_with_unknown_entries.se" }
+
+    context 'lenient parser' do
+      let(:parser) {Sie::Parser.new(lenient: true)}
+
+      it "handles unknown entries without raising error" do
+        open_file(file_with_unknown_entries) do |f|
+          expect { parser.parse(f) }.not_to raise_error
+        end
+      end
+
+      it "continues to parse the complete file after unknown entries" do
+        open_file(file_with_unknown_entries) do |f|
+          sie_file = parser.parse(f)
+
+          expect(sie_file.entries_with_label("ver").size).to eq(2)
+        end
+      end
+    end
+
+    context 'rigorous parser' do
+      let(:parser) {Sie::Parser.new}
+
+      it "raises error when encountering unknown entries" do
+        open_file(file_with_unknown_entries) do |f|
+          expect { parser.parse(f) }.to raise_error
+        end
+      end
+    end
+  end
+
+  def open_file(fixture_file, &block)
+    File.open(File.join(File.dirname(__FILE__), "../#{fixture_file}"), &block)
   end
 end

--- a/spec/integration/parser_spec.rb
+++ b/spec/integration/parser_spec.rb
@@ -18,11 +18,11 @@ describe Sie::Parser do
     end
   end
 
-  context 'unknown entries' do
+  context "with unknown entries" do
     let(:file_with_unknown_entries) { "fixtures/sie_file_with_unknown_entries.se" }
 
-    context 'lenient parser' do
-      let(:parser) {Sie::Parser.new(lenient: true)}
+    context "using a lenient parser" do
+      let(:parser) { Sie::Parser.new(lenient: true) }
 
       it "handles unknown entries without raising error" do
         open_file(file_with_unknown_entries) do |f|
@@ -39,8 +39,8 @@ describe Sie::Parser do
       end
     end
 
-    context 'rigorous parser' do
-      let(:parser) {Sie::Parser.new}
+    context "with strict parser" do
+      let(:parser) { Sie::Parser.new }
 
       it "raises error when encountering unknown entries" do
         open_file(file_with_unknown_entries) do |f|

--- a/spec/unit/parser/line_parser_spec.rb
+++ b/spec/unit/parser/line_parser_spec.rb
@@ -14,6 +14,26 @@ describe Sie::Parser::LineParser, "parse" do
     })
   end
 
+  context "unknown entry" do
+    let(:line) { "#MOMSKOD 2611 10"}
+
+    context "lenient parser" do
+      let(:parser) { Sie::Parser::LineParser.new(line, lenient: true) }
+
+      it "raises no error when encountering unknown entries" do
+        expect { parser.parse }.not_to raise_error
+      end
+    end
+
+    context "rigorous parser" do
+      let(:parser) { Sie::Parser::LineParser.new(line) }
+
+      it "raises error when encountering unknown entries" do
+        expect { parser.parse }.to raise_error
+      end
+    end
+  end
+
   it "fails if you have non empty metadata arrays until there is a need to support that" do
     parser = Sie::Parser::LineParser.new('#TRANS 2400 { 1 "2" } -200 20130101 "Foocorp expense"')
     expect(-> { parser.parse }).to raise_error(/don't support metadata/)

--- a/spec/unit/parser/line_parser_spec.rb
+++ b/spec/unit/parser/line_parser_spec.rb
@@ -14,10 +14,10 @@ describe Sie::Parser::LineParser, "parse" do
     })
   end
 
-  context "unknown entry" do
+  context "with unknown entry" do
     let(:line) { "#MOMSKOD 2611 10"}
 
-    context "lenient parser" do
+    context "using a lenient parser" do
       let(:parser) { Sie::Parser::LineParser.new(line, lenient: true) }
 
       it "raises no error when encountering unknown entries" do
@@ -25,7 +25,7 @@ describe Sie::Parser::LineParser, "parse" do
       end
     end
 
-    context "rigorous parser" do
+    context "using a strict parser" do
       let(:parser) { Sie::Parser::LineParser.new(line) }
 
       it "raises error when encountering unknown entries" do


### PR DESCRIPTION
I had some trouble parsing a SIE file with entries like `#MOMSKOD 2611 10`. When parsing such a file I get

    key not found: "momskod"
    sie (2.1.0) lib/sie/parser/tokenizer/token.rb:14:in `fetch'
    sie (2.1.0) lib/sie/parser/tokenizer/token.rb:14:in `entry_type'
    sie (2.1.0) lib/sie/parser/line_parser.rb:15:in `parse'
    sie (2.1.0) lib/sie/parser.rb:37:in `parse_line'
    sie (2.1.0) lib/sie/parser.rb:27:in `block in parse'
    sie (2.1.0) lib/sie/parser.rb:17:in `each_line'
    sie (2.1.0) lib/sie/parser.rb:17:in `parse'

This is understandable because as far as I can tell #MOMSKOD is not mentioned in the spec. The file I tried to parse is exported from iOrdning and I don't know if MOMSKOD is some custom extension or if it's from an older version of the spec. 

Anyway, I still need to be able to parse files like these so I tried to introduce an option to make the parser more lenient regarding unknown entry types. Given `lenient: true` the parser now handles unknown entry types without raising any error. Without the option it still raises an error. See the updated specs for details.

There might be things to discuss regarding the implementation but first of all I'd like to know if you'd consider such an option useful.
