### PR TITLE
Handle tab character, quote escaping and forbidden control characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.idea

--- a/lib/sie/parser/tokenizer.rb
+++ b/lib/sie/parser/tokenizer.rb
@@ -70,7 +70,7 @@ module Sie
         elsif current_character.non_whitespace?
           @consume = true
           add_token StringToken.new(current_character.value)
-        elsif current_character.value != " "
+        elsif current_character.value != " " && current_character.value != "\t"
           raise "Unhandled character: #{current_character.value}"
         end
       end

--- a/lib/sie/parser/tokenizer.rb
+++ b/lib/sie/parser/tokenizer.rb
@@ -25,9 +25,6 @@ module Sie
             when end_array?
               tokens << EndArrayToken.new
 
-            when match = quoted_string?
-              tokens << StringToken.new(match)
-
             when match = string?
               tokens << StringToken.new(match)
 
@@ -68,18 +65,28 @@ module Sie
         scanner.scan(/}/)
       end
 
-      def quoted_string?
-        match = scanner.scan(/"(\\"|[^"])*"/)
+      def string?
+        match = quoted_string? || unquoted_string?
 
         if match
-          match.sub!(/\A"/, "")
-          match.sub!(/"\z/, "")
-          match.gsub!(/\\"/, "\"")
-          match
+          handle_escapes(match)
         end
       end
 
-      def string?
+      def handle_escapes(match)
+        match.gsub!(/\\([\\"])/, "\\1")
+        match
+      end
+
+      def quoted_string?
+        match = scanner.scan(/"(\\"|[^"])*"/)
+        if match
+          match.sub!(/\A"/, "")
+          match.sub!(/"\z/, "")
+        end
+      end
+
+      def unquoted_string?
         scanner.scan(/\S+/)
       end
 

--- a/spec/unit/parser/tokenizer_spec.rb
+++ b/spec/unit/parser/tokenizer_spec.rb
@@ -43,6 +43,34 @@ describe Sie::Parser::Tokenizer do
                                           ])
   end
 
+  it 'handles escaped quotes in non-quoted strings' do
+    tokenizer = Sie::Parser::Tokenizer.new('String_with_\\"_quote')
+    tokens = tokenizer.tokenize
+
+    expect(token_table_for(tokens)).to eq([
+                                              [ "StringToken", 'String_with_"_quote']
+                                          ])
+  end
+
+  it 'handles escaped backslash in strings' do
+    tokenizer = Sie::Parser::Tokenizer.new('"String with \\\\ backslash"')
+    tokens = tokenizer.tokenize
+
+    expect(token_table_for(tokens)).to eq([
+                                              [ "StringToken", 'String with \\ backslash']
+                                          ])
+  end
+
+  it 'has reasonable behavior for consecutive escape characters' do
+    tokenizer = Sie::Parser::Tokenizer.new('"\\\\\\"\\\\"')
+    tokens = tokenizer.tokenize
+
+    expect(token_table_for(tokens)).to eq([
+                                              [ "StringToken", '\\"\\']
+                                          ])
+
+  end
+
   it 'handles tab character as field separator' do
     tokenizer = Sie::Parser::Tokenizer.new("#TRANS\t2400")
     tokens = tokenizer.tokenize

--- a/spec/unit/parser/tokenizer_spec.rb
+++ b/spec/unit/parser/tokenizer_spec.rb
@@ -3,7 +3,7 @@ require "sie/parser/tokenizer"
 
 describe Sie::Parser::Tokenizer do
   it "tokenizes the given line" do
-    tokenizer = Sie::Parser::Tokenizer.new('#TRANS 2400 {} -200 20130101 "Foocorp expense"')
+    tokenizer = Sie::Parser::Tokenizer.new("#TRANS\t2400 {} -200 20130101 \"Foocorp expense\"")
     tokens = tokenizer.tokenize
 
     expect(token_table_for(tokens)).to eq([


### PR DESCRIPTION
The current version of the gem doesn't work with tabs as whitespace, even though the Character class supports it. There is a bug in the tokenizer, in the last condition of the add_new_token method.

I did the simplest thing I could to get it to work, and pushed a forked version to our production, but then I looked more closely and found a couple of other things that don't work. The specification says that strings may contain escaped quotes (i.e. \"), and that control characters are not allowed. I tried to update the tokenizer to support this, but it became too messy, so I wrote a new one from scratch. Feel free to reject my implementation, but I have some extra tests for cases the current implementation doesn't handle.

One slightly unclear point in the SIE specification is quote escaping. In section 5.7, it says that quotes may be escaped using backslash in strings, but it doesn't say anything about escaping backslash itself. Also, it doesn't say whether escapes are allowed with non-quoted strings. I've assumed that backslash must be escaped and that escaping is allowed in any string, quoted or not.

Control characters seem very unlikely in reality, but since the spec explicitly forbids them, I added that check as well.