### PR TITLE
Fortnox has raised the description limit to 200 characters.

### DIFF
--- a/lib/sie/document.rb
+++ b/lib/sie/document.rb
@@ -6,7 +6,7 @@ require "active_support/core_ext/module/delegation"
 module Sie
   class Document
     # Because fortnox imposes these limits
-    DESCRIPTION_LENGTH_MAX = 30
+    DESCRIPTION_LENGTH_MAX = 200
 
     pattr_initialize :data_source
 
@@ -111,7 +111,7 @@ module Sie
           amount         = line.fetch(:amount)
           booked_on      = line.fetch(:booked_on)
           dimensions     = line.fetch(:dimensions, {}).flatten
-          # Some SIE-importers (fortnox) cannot handle descriptions longer than 30 characters,
+          # Some SIE-importers (fortnox) cannot handle descriptions longer than 200 characters,
           # but the specification has no limit.
           description    = line.fetch(:description).slice(0, DESCRIPTION_LENGTH_MAX)
 

--- a/spec/unit/document_spec.rb
+++ b/spec/unit/document_spec.rb
@@ -202,15 +202,15 @@ describe Sie::Document, "#render" do
   context "with really long descriptions" do
     let(:accounts) {
       [
-        number: 1500, description: "Customer ledger with really really long description blablabla"
+        number: 1500, description: "Customer ledger with really really long description. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut. Truncated"
       ]
     }
     let(:vouchers) {
       [
         build_voucher(
-          description: "Payout 1 with really really long description blablabla",
+          description: "Payout 1 with really really long description. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi e. Truncated",
           voucher_lines: [
-            build_voucher_line(description: "Payout line 1 with really really long description blablabla"),
+            build_voucher_line(description: "Payout line 1 with really really long description. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wi. Truncated"),
             build_voucher_line(description: "Payout line 2"),
           ]
         )
@@ -218,9 +218,9 @@ describe Sie::Document, "#render" do
     }
 
     it "truncates the descriptions" do
-      expect(indexed_entry_attributes("konto", 0)).to eq("kontonr" => "1500", "kontonamn" => "Customer ledger with really re")
-      expect(indexed_entry("ver", 0).attributes["vertext"]).to eq("Payout 1 with really really lo")
-      expect(indexed_voucher_entries(0)[0].attributes["transtext"]).to eq("Payout line 1 with really real")
+      expect(indexed_entry_attributes("konto", 0)).to eq("kontonr" => "1500", "kontonamn" => "Customer ledger with really really long description. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut")
+      expect(indexed_entry("ver", 0).attributes["vertext"]).to eq("Payout 1 with really really long description. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut wisi e")
+      expect(indexed_voucher_entries(0)[0].attributes["transtext"]).to eq("Payout line 1 with really really long description. Lorem ipsum dolor sit amet, consectetuer adipiscing elit, sed diam nonummy nibh euismod tincidunt ut laoreet dolore magna aliquam erat volutpat. Ut w")
     end
   end
 


### PR DESCRIPTION
Quoting reply from fortnox:
>Erik Svedström (Fortnox)
2 dec. 15:38
Hej,
Vi har en begränsning på 200 tecken i beskrivningsfältet via import, API samt gränssnitt.
Ha en trevlig dag!
Med vänliga hälsningar
Erik Svedström
Fortnox AB | Tel
integration@fortnox.se | http://www.fortnox.se