### PR TITLE
CI: Test only on supported Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
+  - 2.7
   - 2.6
   - 2.5
-  - 2.4

--- a/sie.gemspec
+++ b/sie.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "attr_extras"
   spec.add_dependency "activesupport"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler", ">= 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"
 end


### PR DESCRIPTION
This PR removes 2.4 from the matrix. And adds 2.7. https://www.ruby-lang.org/en/downloads/branches/ lists the support schedule for Ruby-the-language.

(In order to be able to run the tests, allow Bundler 2, too.)