### PR TITLE
Change regex in Tokenizer.find_unquoted_string

### DIFF
--- a/lib/sie/parser/tokenizer.rb
+++ b/lib/sie/parser/tokenizer.rb
@@ -88,7 +88,7 @@ module Sie
       end
 
       def find_unquoted_string
-        scanner.scan(/\S+/)
+        scanner.scan(/[^}\s]+/)
       end
 
       def remove_unnecessary_escapes(match)

--- a/spec/unit/parser/tokenizer_spec.rb
+++ b/spec/unit/parser/tokenizer_spec.rb
@@ -34,6 +34,23 @@ describe Sie::Parser::Tokenizer do
     ])
   end
 
+  it "can parse metadata arrays without quotation marks nor spaces" do
+    tokenizer = Sie::Parser::Tokenizer.new('#TRANS 2400 {1 2} -200 20130101 "Foocorp expense"')
+    tokens = tokenizer.tokenize
+
+    expect(token_table_for(tokens)).to eq([
+      [ "EntryToken", "TRANS" ],
+      [ "StringToken", "2400" ],
+      [ "BeginArrayToken", "" ],
+      [ "StringToken", "1" ],
+      [ "StringToken", "2" ],
+      [ "EndArrayToken", "" ],
+      [ "StringToken", "-200" ],
+      [ "StringToken", "20130101" ],
+      [ "StringToken", "Foocorp expense" ],
+    ])
+  end
+
   it "handles escaped quotes in quoted strings" do
     tokenizer = Sie::Parser::Tokenizer.new('"String with \\" quote"')
     tokens = tokenizer.tokenize


### PR DESCRIPTION
A row like:
`#TRANS 3010 {2 95} -1084.80 20220413 "example text"`
will result in a `objektlista` with `2` as a key with value `"95}"`. `-1084.80` as key with value `"20220413"`. `"example text"` as a key with value `nil`. The array isn't ending. It continues the whole line.

`{2 "95"}` works. 
`{2 95 }` works.
`{2 95}` fails.

This PR includes a change in the regular expression in the method `find_unquoted_string` in `Tokenizer`.